### PR TITLE
회원 정보 페이지에 담을 정보 수정

### DIFF
--- a/QuantumTec/src/main/java/com/project/quantumtec/Controller/UserController.java
+++ b/QuantumTec/src/main/java/com/project/quantumtec/Controller/UserController.java
@@ -2,6 +2,7 @@ package com.project.quantumtec.Controller;
 
 import com.project.quantumtec.DTO.user.LoginRequestDTO;
 import com.project.quantumtec.DTO.user.LoginResponseDTO;
+import com.project.quantumtec.DTO.user.UserInfoDTO;
 import com.project.quantumtec.DTO.user.singupEmailCodeDTO;
 import com.project.quantumtec.Service.user.UserService;
 import com.project.quantumtec.VO.user.UserVO;
@@ -24,8 +25,8 @@ public class UserController {
 
     // UserService 의 입력받은 회원정보를 DB에 저장하는 메소드
     @PostMapping("/signup")
-    public UserVO signupAdd(@RequestBody UserVO user) throws Exception {
-        UserVO checkUser = userService.signup(user);
+    public UserInfoDTO signupAdd(@RequestBody UserVO user) throws Exception {
+        UserInfoDTO checkUser = userService.signup(user);
         if(checkUser != null) {
             return checkUser;
         }else {
@@ -61,7 +62,7 @@ public class UserController {
 
     // 아이디, 비밀번호를 조회하여 그에 해당하는 회원정보 페이지에 출력할 회원정보를 반환하는 메소드
     @PostMapping("/myinfo")
-    public UserVO getUserInfo(@RequestBody UserVO user) throws Exception {
+    public UserInfoDTO getUserInfo(@RequestBody UserVO user) throws Exception {
         return userService.getUserInfo(user.getUserID(), user.getUserPW());
     }
     // UserService 의 입력받은 회원정보를 삭제하는 메소드

--- a/QuantumTec/src/main/java/com/project/quantumtec/DAO/user/UserDAO.java
+++ b/QuantumTec/src/main/java/com/project/quantumtec/DAO/user/UserDAO.java
@@ -1,6 +1,7 @@
 package com.project.quantumtec.DAO.user;
 
 import com.project.quantumtec.DTO.user.LoginResponseDTO;
+import com.project.quantumtec.DTO.user.UserInfoDTO;
 import com.project.quantumtec.VO.user.UserVO;
 
 import java.util.List;
@@ -19,7 +20,7 @@ public interface UserDAO {
     public int getUserExist(String userID, String userPW) throws Exception;
 
     // 사용자 정보 가져오기
-    public UserVO getUserInfo(int userIdx) throws Exception;
+    public UserInfoDTO getUserInfo(int userIdx) throws Exception;
 
     // 로그인 정보 가져오기
     public LoginResponseDTO getLoginInfo(int userIdx) throws Exception;

--- a/QuantumTec/src/main/java/com/project/quantumtec/DAO/user/UserDAOImpl.java
+++ b/QuantumTec/src/main/java/com/project/quantumtec/DAO/user/UserDAOImpl.java
@@ -1,13 +1,12 @@
 package com.project.quantumtec.DAO.user;
 
-import com.project.quantumtec.DTO.user.LoginRequestDTO;
 import com.project.quantumtec.DTO.user.LoginResponseDTO;
 import com.project.quantumtec.DTO.user.UserDTO;
+import com.project.quantumtec.DTO.user.UserInfoDTO;
 import com.project.quantumtec.VO.user.UserVO;
 import org.apache.ibatis.session.SqlSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
-import org.springframework.web.servlet.FlashMap;
 
 import java.util.List;
 
@@ -53,7 +52,7 @@ public class UserDAOImpl implements UserDAO{
 
     // 유저 인덱스를 입력받아 사용자 정보를 가져오는 함수
     @Override
-    public UserVO getUserInfo(int userIdx) throws Exception {
+    public UserInfoDTO getUserInfo(int userIdx) throws Exception {
         return sqlSession.selectOne("UserService.getUserInfo", userIdx);
     }
 

--- a/QuantumTec/src/main/java/com/project/quantumtec/DTO/user/UserInfoDTO.java
+++ b/QuantumTec/src/main/java/com/project/quantumtec/DTO/user/UserInfoDTO.java
@@ -1,0 +1,19 @@
+package com.project.quantumtec.DTO.user;
+
+import lombok.Data;
+
+@Data
+public class UserInfoDTO {
+    private String userID;          // 사용자 아이디
+    private String userPW;          // 사용자 비밀번호
+    private String userNickname;    // 사용자 닉네임
+    private String userName;        // 사용자 이름
+    private String userBirth;       // 사용자 생일
+    private String userAddress;         // 사용자 기본주소
+    private String userAddressDetail;   // 사용자 상세주소
+    private String userPostal;          // 사용자 우편번호
+    private String userEmail;           // 사용자 이메일
+    private String userRole;            // 사용자 권한
+    private String userCash;            // 사용자 캐시
+    private String userStatus;           // 사용자 상태
+}

--- a/QuantumTec/src/main/java/com/project/quantumtec/DTO/user/UserInfoDTO.java
+++ b/QuantumTec/src/main/java/com/project/quantumtec/DTO/user/UserInfoDTO.java
@@ -5,7 +5,6 @@ import lombok.Data;
 @Data
 public class UserInfoDTO {
     private String userID;          // 사용자 아이디
-    private String userPW;          // 사용자 비밀번호
     private String userNickname;    // 사용자 닉네임
     private String userName;        // 사용자 이름
     private String userBirth;       // 사용자 생일

--- a/QuantumTec/src/main/java/com/project/quantumtec/Service/user/UserService.java
+++ b/QuantumTec/src/main/java/com/project/quantumtec/Service/user/UserService.java
@@ -1,6 +1,7 @@
 package com.project.quantumtec.Service.user;
 
 import com.project.quantumtec.DTO.user.LoginResponseDTO;
+import com.project.quantumtec.DTO.user.UserInfoDTO;
 import com.project.quantumtec.DTO.user.singupEmailCodeDTO;
 import com.project.quantumtec.VO.user.UserVO;
 
@@ -21,12 +22,12 @@ public interface UserService {
     // 로그인
 //    public UserVO login(String userID, String userPW) throws Exception;
 
-    public UserVO getUserInfo(String userID, String userPW) throws Exception;
+    public UserInfoDTO getUserInfo(String userID, String userPW) throws Exception;
     // 새로운 로그인 친구
     public LoginResponseDTO login(String userID, String userPW)  throws Exception;
 
     // 회원가입
-    public UserVO signup(UserVO user) throws Exception;
+    public UserInfoDTO signup(UserVO user) throws Exception;
 
     // 아이디 중복 확인
     public boolean checkDuplicateId(UserVO user) throws Exception;

--- a/QuantumTec/src/main/java/com/project/quantumtec/Service/user/UserServiceImpl.java
+++ b/QuantumTec/src/main/java/com/project/quantumtec/Service/user/UserServiceImpl.java
@@ -2,6 +2,7 @@ package com.project.quantumtec.Service.user;
 
 import com.project.quantumtec.DAO.user.UserDAO;
 import com.project.quantumtec.DTO.user.LoginResponseDTO;
+import com.project.quantumtec.DTO.user.UserInfoDTO;
 import com.project.quantumtec.DTO.user.singupEmailCodeDTO;
 import com.project.quantumtec.Utils.user.emailApi.EmailApi;
 import com.project.quantumtec.Utils.user.emailApi.EmailApiImpl;
@@ -46,7 +47,7 @@ public class UserServiceImpl implements UserService{
     }
 
     @Override
-    public UserVO getUserInfo(String userID, String userPW) throws Exception {
+    public UserInfoDTO getUserInfo(String userID, String userPW) throws Exception {
         int checkUser = userDAO.getUserExist(userID, userPW);
 
         if(checkUser >= 1) {
@@ -57,7 +58,7 @@ public class UserServiceImpl implements UserService{
     }
 
     @Override
-    public UserVO signup(UserVO user) throws Exception {
+    public UserInfoDTO signup(UserVO user) throws Exception {
         // 0: 회원가입 실패, 1: 회원가입 성공
         int checkSignUp = userDAO.setUser(user);
 

--- a/QuantumTec/src/main/resources/mapper/userMapper.xml
+++ b/QuantumTec/src/main/resources/mapper/userMapper.xml
@@ -10,10 +10,10 @@
         from userInfo
         where user_id = #{userID} and user_pw = #{userPW}
     </select>
-    <select id="getUserInfo" resultType="UserVO" parameterType="int">
-        select *
-        from userInfo
-        where user_idx = #{userIdx}
+    <select id="getUserInfo" resultType="UserInfoDTO" parameterType="int">
+        select user_id,user_pw,user_nickname,user_name,user_birth,user_address,user_address_detail,user_postal,user_email,user_role,user_cash,user_status
+        from userInfo, userStatus
+        where userInfo.user_idx = #{userIdx} and userStatus.user_idx = #{userIdx}
     </select>
     <select id="getLoginInfo" resultType="LoginResponseDTO" parameterType="int">
         select user_nickname, user_cash

--- a/QuantumTec/src/main/resources/mapper/userMapper.xml
+++ b/QuantumTec/src/main/resources/mapper/userMapper.xml
@@ -11,7 +11,7 @@
         where user_id = #{userID} and user_pw = #{userPW}
     </select>
     <select id="getUserInfo" resultType="UserInfoDTO" parameterType="int">
-        select user_id,user_pw,user_nickname,user_name,user_birth,user_address,user_address_detail,user_postal,user_email,user_role,user_cash,user_status
+        select user_id,user_nickname,user_name,user_birth,user_address,user_address_detail,user_postal,user_email,user_role,user_cash,user_status
         from userInfo, userStatus
         where userInfo.user_idx = #{userIdx} and userStatus.user_idx = #{userIdx}
     </select>


### PR DESCRIPTION
회원 idx는 제외하고, 회원의 status와 회원의 cash 데이터를 추가한 뒤에,
이를 UserVO대신 UserInfoDTO에 담아서 반환한다.